### PR TITLE
adds procfile to order group

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -44,3 +44,8 @@ api = "0.2"
   [[order.group]]
     id = "paketo-buildpacks/dotnet-execute"
     version = "0.2.1"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "3.0.0"

--- a/package.toml
+++ b/package.toml
@@ -22,3 +22,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/dotnet-publish:0.1.0"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/procfile:3.0.0"


### PR DESCRIPTION


Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:

adds procfile to order group

[paketo-buildpacks/dotnet-core/issues/6]

- needs paketo-buildpacks/dotnet-publish/pull/125 in order for the
acceptance tests to pass

* An explanation of the use cases your change enables:

Users will be able to write their own start commands for dotnet apps

Please confirm the following:
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
