### PR TITLE
Add procfile to order groupings

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -42,6 +42,11 @@ api = "0.2"
     id = "paketo-buildpacks/dotnet-execute"
     version = "0.3.0"
 
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "3.0.0"
+    optional = true
+
 [[order]] # Framework-dependent deployment and Framework-dependent executable apps
 
   [[order.group]]
@@ -72,6 +77,11 @@ api = "0.2"
     id = "paketo-buildpacks/dotnet-execute"
     version = "0.3.0"
 
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "3.0.0"
+    optional = true
+
 [[order]] # Self-contained apps
 
   [[order.group]]
@@ -87,3 +97,8 @@ api = "0.2"
   [[order.group]]
     id = "paketo-buildpacks/dotnet-execute"
     version = "0.3.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    version = "3.0.0"
+    optional = true

--- a/integration/fde_test.go
+++ b/integration/fde_test.go
@@ -88,5 +88,46 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(ContainSubstring("<title>react_app</title>"))
 		})
+
+		context("when the app contains a Procfile", func() {
+			it.Before(func() {
+				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: /workspace/react-app --urls http://0.0.0.0:${PORT:-8080}"), 0644)).To(Succeed())
+			})
+
+			it("creates a working OCI image", func() {
+				var err error
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(dotnetCoreBuildpack).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				container, err = docker.Container.Run.
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					WithPublishAll().
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+
+				Expect(logs).To(ContainLines(ContainSubstring("ICU Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring(".NET Core Runtime Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("ASP.Net Core Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring(".NET Execute Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+
+				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
+
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+				content, err := ioutil.ReadAll(response.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(ContainSubstring("<title>react_app</title>"))
+			})
+		})
 	})
 }

--- a/integration/self_contained_test.go
+++ b/integration/self_contained_test.go
@@ -86,5 +86,44 @@ func testSelfContained(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(ContainSubstring("<title>react_app</title>"))
 		})
+
+		context("when the app contains a Procfile", func() {
+			it.Before(func() {
+				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: /workspace/react-app --urls http://0.0.0.0:${PORT:-8080}"), 0644)).To(Succeed())
+			})
+
+			it("creates a working OCI image", func() {
+				var err error
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(dotnetCoreBuildpack).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				container, err = docker.Container.Run.
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					WithPublishAll().
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+
+				Expect(logs).To(ContainLines(ContainSubstring("ICU Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring(".NET Execute Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+
+				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
+
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+				content, err := ioutil.ReadAll(response.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(ContainSubstring("<title>react_app</title>"))
+			})
+		})
 	})
 }

--- a/integration/source_test.go
+++ b/integration/source_test.go
@@ -90,5 +90,48 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(ContainSubstring("<title>react_app</title>"))
 		})
+
+		context("when the app contains a Procfile", func() {
+			it.Before(func() {
+				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: /workspace/react-app --urls http://0.0.0.0:${PORT:-8080}"), 0644)).To(Succeed())
+			})
+
+			it("creates a working OCI image", func() {
+				var err error
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(dotnetCoreBuildpack).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				container, err = docker.Container.Run.
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					WithPublishAll().
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+
+				Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("ICU Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring(".NET Core Runtime Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("ASP.Net Core Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring(".NET SDK Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring(".Net Publish Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+
+				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
+
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+				content, err := ioutil.ReadAll(response.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(ContainSubstring("<title>react_app</title>"))
+			})
+		})
 	})
 }

--- a/package.toml
+++ b/package.toml
@@ -22,3 +22,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/dotnet-publish:0.1.1"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/procfile:3.0.0"


### PR DESCRIPTION
Signed-off-by: Sophie Wigmore <swigmore@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds the Procfile buildpack to order groupings per issue https://github.com/paketo-buildpacks/dotnet-core/issues/6

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
