### PR TITLE
adds env vars bp optionally to all groups

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -47,6 +47,11 @@ api = "0.2"
     optional = true
     version = "4.0.0"
 
+  [[order.group]]
+    id = "paketo-buildpacks/environment-variables"
+    optional = true
+    version = "3.0.0"
+
 [[order]]
 
   [[order.group]]
@@ -82,6 +87,11 @@ api = "0.2"
     optional = true
     version = "4.0.0"
 
+  [[order.group]]
+    id = "paketo-buildpacks/environment-variables"
+    optional = true
+    version = "3.0.0"
+
 [[order]]
 
   [[order.group]]
@@ -102,3 +112,8 @@ api = "0.2"
     id = "paketo-buildpacks/procfile"
     optional = true
     version = "4.0.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/environment-variables"
+    optional = true
+    version = "3.0.0"

--- a/integration/fdd_test.go
+++ b/integration/fdd_test.go
@@ -79,6 +79,8 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring(".NET Execute Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("web: dotnet /workspace/react-app.dll --urls http://0.0.0.0:${PORT:-8080}")))
 
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+
 			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
@@ -90,17 +92,20 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 			Expect(string(content)).To(ContainSubstring("<title>react_app</title>"))
 		})
 
-		context("when the app contains a Procfile", func() {
+		context("when using optional utility buildpacks", func() {
 			it.Before(func() {
 				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: echo Procfile command && dotnet /workspace/react-app.dll --urls http://0.0.0.0:${PORT:-8080}"), 0644)).To(Succeed())
 			})
 
-			it("creates a working OCI image", func() {
+			it("builds a working OCI image and run the app with the start command from the Procfile and other utility buildpacks", func() {
 				var err error
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(dotnetCoreBuildpack).
 					WithPullPolicy("never").
+					WithEnv(map[string]string{
+						"BPE_SOME_VARIABLE": "some-value",
+					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
@@ -119,6 +124,10 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("ICU Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring(".NET Execute Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+
+				Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())

--- a/integration/fde_test.go
+++ b/integration/fde_test.go
@@ -78,6 +78,8 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring(".NET Execute Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("web: /workspace/react-app --urls http://0.0.0.0:${PORT:-8080}")))
 
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+
 			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
@@ -89,17 +91,20 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 			Expect(string(content)).To(ContainSubstring("<title>react_app</title>"))
 		})
 
-		context("when the app contains a Procfile", func() {
+		context("when using optional utility buildpacks", func() {
 			it.Before(func() {
 				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: echo Procfile command && /workspace/react-app --urls http://0.0.0.0:${PORT:-8080}"), 0644)).To(Succeed())
 			})
 
-			it("creates a working OCI image", func() {
+			it("builds a working OCI image and run the app with the start command from the Procfile and other utility buildpacks", func() {
 				var err error
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(dotnetCoreBuildpack).
 					WithPullPolicy("never").
+					WithEnv(map[string]string{
+						"BPE_SOME_VARIABLE": "some-value",
+					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
@@ -117,6 +122,10 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("ICU Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring(".NET Execute Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+
+				Expect(image.Buildpacks[5].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[5].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())

--- a/integration/source_test.go
+++ b/integration/source_test.go
@@ -80,6 +80,8 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring(".NET Publish Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring(".NET Execute Buildpack")))
 
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+
 			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
@@ -91,17 +93,20 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 			Expect(string(content)).To(ContainSubstring("<title>react_app</title>"))
 		})
 
-		context("when the app contains a Procfile", func() {
+		context("when using optional utility buildpacks", func() {
 			it.Before(func() {
 				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: echo Procfile command && /workspace/react-app --urls http://0.0.0.0:${PORT:-8080}"), 0644)).To(Succeed())
 			})
 
-			it("creates a working OCI image", func() {
+			it("builds a working OCI image and run the app with the start command from the Procfile and other utility buildpacks", func() {
 				var err error
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(dotnetCoreBuildpack).
 					WithPullPolicy("never").
+					WithEnv(map[string]string{
+						"BPE_SOME_VARIABLE": "some-value",
+					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
@@ -121,6 +126,10 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring(".NET Publish Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+
+				Expect(image.Buildpacks[8].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[8].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())

--- a/package.toml
+++ b/package.toml
@@ -25,3 +25,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/procfile:4.0.0"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/environment-variables:3.0.0"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Resolves #349 

## Use Cases
<!-- An explanation of the use cases your change enables -->
Users can now specify launch-time env vars that should be set in the app container with `BPE_` prefixed environment variables provided at build time.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
