### PR TITLE
add workflow to tag docs release on repo release

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,1 +1,2 @@
 CODEOWNERS
+workflows/tag-docs-release.yml

--- a/.github/workflows/tag-docs-release.yml
+++ b/.github/workflows/tag-docs-release.yml
@@ -1,0 +1,37 @@
+name: Tag Documentation Release
+
+on:
+  release:
+    types:
+    - published
+  workflow_dispatch: {}
+
+jobs:
+  tag:
+    name: Tag
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Parse Event
+      id: event
+      run: |
+        echo "::set-output name=tag::$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)"
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      fetch-depth: 0
+
+    - name: Get Release Tag
+      id: tag
+      uses: paketo-buildpacks/github-config/actions/tag/tag-docs-submodule@main
+      with:
+        version: ${{ steps.event.outputs.tag }}
+
+    - name: Create Docs Tag
+      run: |
+       git tag ${{ steps.tag.outputs.tag }}
+
+    - name: Push
+      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+      with:
+        branch: main


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This workflow runs when a release is cut on the repo. It creates a new tag `docs/vX.Y.Z` where `vX.Y.Z` is the version of the release that's cut on the repo. Because Hugo modules requires that the `docs` subdirectory have its own `go.mod`, that makes the subdirectory a go submodule. Tags prefixed with `docs/` are the version tags for the submodule. Since the `docs/` directory isn't just a package, its versioning does not come directly from the repo's main tags. (See https://github.com/go-modules-by-example/index/blob/master/009_submodules/README.md) for an explanation of Go submodules and their versioning.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
