### PR TITLE
Fix tag docs release workflow

### DIFF
--- a/.github/workflows/tag-docs-release.yml
+++ b/.github/workflows/tag-docs-release.yml
@@ -31,8 +31,4 @@ jobs:
     - name: Create Docs Tag
       run: |
        git tag ${{ steps.tag.outputs.tag }}
-
-    - name: Push
-      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
-      with:
-        branch: main
+       git push origin ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/tag-docs-release.yml
+++ b/.github/workflows/tag-docs-release.yml
@@ -4,12 +4,8 @@ on:
   release:
     types:
     - published
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
-        default: false
+  workflow_dispatch: {}
+
 jobs:
   tag:
     name: Tag
@@ -31,11 +27,6 @@ jobs:
       uses: paketo-buildpacks/github-config/actions/tag/tag-docs-submodule@main
       with:
         version: ${{ steps.event.outputs.tag }}
-
-    # Enable tmate debugging of manually-triggered workflows if the input option was provided
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
     - name: Create Docs Tag
       run: |


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
A previous iteration of the tag docs release workflow was failing because it used the push-branch github action instead of using the proper `git push origin <tagname>` syntax. 

This pull request a) fixes the tag docs release workflow and b) rolls back the tmate change because, as it turns out, this workflow doesn't really run happily starting from a `workflow_dispatch` because it examines the `release` event payload.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Ideally, with this workflow fixed, cutting releases of the buildpack will automatically create a tag for the docs release. 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
