### PR TITLE
Remove markdown h1

### DIFF
--- a/docs/content/dotnet-core.md
+++ b/docs/content/dotnet-core.md
@@ -6,8 +6,6 @@ menu:
     parent: "language-family-buildpacks"
 ---
 
-# .Net Core Buildpack
-
 The [.Net Core Paketo Buildpack](https://github.com/paketo-buildpacks/dotnet-core)
 supports building several configurations of .Net Core applications.
 


### PR DESCRIPTION
Page title will instead be rendered by Hugo templating using the file's `title` attribute. See https://github.com/paketo-buildpacks/paketo-website/pull/188

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
To facilitate the redesign of the docs on the website, we have removed H1 markdown headers from docs pages and instead used the `.Title` attribute of pages to determine the h1 for the page.

See https://github.com/paketo-buildpacks/paketo-website/pull/188

## Use Cases
<!-- An explanation of the use cases your change enables -->
If this change is not made, the page title will appear twice on the page (as seen on the staging site: https://paketo-staging--table-of-contents-89y3arbg.web.app/docs/buildpacks/language-family-buildpacks/dotnet-core/)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
