### PR TITLE
Enable BP_LIVE_RELOAD_ENABLED

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -17,6 +17,11 @@ api = "0.2"
     version = "2.4.2"
 
   [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "1.2.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/dotnet-core-runtime"
     version = "0.2.2"
 
@@ -70,6 +75,11 @@ api = "0.2"
     version = "2.4.2"
 
   [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "1.2.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/dotnet-core-runtime"
     version = "0.2.2"
 
@@ -118,6 +128,11 @@ api = "0.2"
     id = "paketo-buildpacks/ca-certificates"
     optional = true
     version = "2.4.2"
+
+  [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "1.2.0"
 
   [[order.group]]
     id = "paketo-buildpacks/icu"

--- a/integration/fdd_test.go
+++ b/integration/fdd_test.go
@@ -188,8 +188,9 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 					WithBuildpacks(dotnetCoreBuildpack).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BPE_SOME_VARIABLE": "some-value",
-						"BP_IMAGE_LABELS":   "some-label=some-value",
+						"BPE_SOME_VARIABLE":      "some-value",
+						"BP_IMAGE_LABELS":        "some-label=some-value",
+						"BP_LIVE_RELOAD_ENABLED": "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -211,9 +212,10 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
 
-				Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[8].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[8].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)

--- a/integration/fde_test.go
+++ b/integration/fde_test.go
@@ -186,8 +186,9 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 					WithBuildpacks(dotnetCoreBuildpack).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BPE_SOME_VARIABLE": "some-value",
-						"BP_IMAGE_LABELS":   "some-label=some-value",
+						"BPE_SOME_VARIABLE":      "some-value",
+						"BP_IMAGE_LABELS":        "some-label=some-value",
+						"BP_LIVE_RELOAD_ENABLED": "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -208,9 +209,10 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
 
-				Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)

--- a/integration/self_contained_test.go
+++ b/integration/self_contained_test.go
@@ -183,8 +183,9 @@ func testSelfContained(t *testing.T, context spec.G, it spec.S) {
 					WithBuildpacks(dotnetCoreBuildpack).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BPE_SOME_VARIABLE": "some-value",
-						"BP_IMAGE_LABELS":   "some-label=some-value",
+						"BPE_SOME_VARIABLE":      "some-value",
+						"BP_IMAGE_LABELS":        "some-label=some-value",
+						"BP_LIVE_RELOAD_ENABLED": "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -203,9 +204,10 @@ func testSelfContained(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
 
-				Expect(image.Buildpacks[4].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[4].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[5].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[5].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)

--- a/integration/source_test.go
+++ b/integration/source_test.go
@@ -190,8 +190,9 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 					WithBuildpacks(dotnetCoreBuildpack).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BPE_SOME_VARIABLE": "some-value",
-						"BP_IMAGE_LABELS":   "some-label=some-value",
+						"BPE_SOME_VARIABLE":      "some-value",
+						"BP_IMAGE_LABELS":        "some-label=some-value",
+						"BP_LIVE_RELOAD_ENABLED": "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -214,9 +215,10 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
 
-				Expect(image.Buildpacks[9].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[9].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[10].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[10].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)

--- a/package.toml
+++ b/package.toml
@@ -34,3 +34,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/ca-certificates:2.4.2"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/watchexec:1.2.0"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
dotnet-execute [v0.5.0](https://github.com/paketo-buildpacks/dotnet-execute/releases/tag/v0.5.0) includes support for `BP_LIVE_RELOAD_ENABLED`. For .NET language family buildpack users to get the benefit of this environment variable, the .NET language family must include the Watchexec buildpack as an optional component.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
