### PR TITLE
Correct race condition in integration tests

### DIFF
--- a/integration/fdd_test.go
+++ b/integration/fdd_test.go
@@ -227,10 +227,11 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(containerLogs.String()).To(ContainSubstring("Procfile command"))
+				Eventually(func() string {
+					containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return containerLogs.String()
+				}).Should(ContainSubstring("Procfile command"))
 			})
 		})
 	})

--- a/integration/fde_test.go
+++ b/integration/fde_test.go
@@ -224,10 +224,11 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(containerLogs.String()).To(ContainSubstring("Procfile command"))
+				Eventually(func() string {
+					containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return containerLogs.String()
+				}).Should(ContainSubstring("Procfile command"))
 			})
 		})
 	})

--- a/integration/self_contained_test.go
+++ b/integration/self_contained_test.go
@@ -218,10 +218,11 @@ func testSelfContained(t *testing.T, context spec.G, it spec.S) {
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(containerLogs.String()).To(ContainSubstring("Procfile command"))
+				Eventually(func() string {
+					containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return containerLogs.String()
+				}).Should(ContainSubstring("Procfile command"))
 			})
 		})
 	})

--- a/integration/source_test.go
+++ b/integration/source_test.go
@@ -231,10 +231,11 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(containerLogs.String()).To(ContainSubstring("Procfile command"))
+				Eventually(func() string {
+					containerLogs, err := docker.Container.Logs.Execute(procfileContainer.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return containerLogs.String()
+				}).Should(ContainSubstring("Procfile command"))
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Integration tests checked container log output once, rather than polling with `Eventually`. This created a race condition between the test runner and the container under test. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
