### PR TITLE
update buildpack orders to reflect rearch

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.6"
   homepage = "https://github.com/paketo-buildpacks/dotnet-core"
   id = "paketo-buildpacks/dotnet-core"
   keywords = ["dotnet"]
-  name = "Paketo .NET Core Buildpack"
+  name = "MODDED Paketo .NET Core Buildpack"
   version = "{{.Version}}"
 
   [[buildpack.licenses]]
@@ -28,15 +28,6 @@ api = "0.6"
     version = "2.4.1"
 
   [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-runtime"
-    version = "0.8.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-aspnet"
-    optional = true
-    version = "0.7.0"
-
-  [[order.group]]
     id = "paketo-buildpacks/dotnet-core-sdk"
     version = "0.7.0"
 
@@ -53,6 +44,12 @@ api = "0.6"
   [[order.group]]
     id = "paketo-buildpacks/dotnet-publish"
     version = "0.7.4"
+
+  [[order.group]]
+    id = "paketo-buildpacks/dotnet-core-aspnet"
+    optional = true
+    version = "0.7.0"
+
 
   [[order.group]]
     id = "paketo-buildpacks/dotnet-execute"
@@ -86,15 +83,6 @@ api = "0.6"
     version = "2.4.1"
 
   [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-runtime"
-    version = "0.8.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-aspnet"
-    optional = true
-    version = "0.7.0"
-
-  [[order.group]]
     id = "paketo-buildpacks/dotnet-core-sdk"
     optional = true
     version = "0.7.0"
@@ -103,6 +91,11 @@ api = "0.6"
     id = "paketo-buildpacks/icu"
     optional = true
     version = "0.1.2"
+
+  [[order.group]]
+    id = "paketo-buildpacks/dotnet-core-aspnet"
+    optional = true
+    version = "0.7.0"
 
   [[order.group]]
     id = "paketo-buildpacks/node-engine"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -29,61 +29,6 @@ api = "0.6"
 
   [[order.group]]
     id = "paketo-buildpacks/dotnet-core-sdk"
-    version = "0.7.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/icu"
-    optional = true
-    version = "0.1.2"
-
-  [[order.group]]
-    id = "paketo-buildpacks/node-engine"
-    optional = true
-    version = "0.12.3"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-publish"
-    version = "0.7.4"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-aspnet"
-    optional = true
-    version = "0.7.0"
-
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-execute"
-    version = "0.9.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/procfile"
-    optional = true
-    version = "5.1.2"
-
-  [[order.group]]
-    id = "paketo-buildpacks/environment-variables"
-    optional = true
-    version = "4.1.2"
-
-  [[order.group]]
-    id = "paketo-buildpacks/image-labels"
-    optional = true
-    version = "4.1.2"
-
-[[order]]
-
-  [[order.group]]
-    id = "paketo-buildpacks/ca-certificates"
-    optional = true
-    version = "3.2.4"
-
-  [[order.group]]
-    id = "paketo-buildpacks/watchexec"
-    optional = true
-    version = "2.4.1"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-sdk"
     optional = true
     version = "0.7.0"
 
@@ -96,47 +41,6 @@ api = "0.6"
     id = "paketo-buildpacks/dotnet-core-aspnet"
     optional = true
     version = "0.7.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/node-engine"
-    optional = true
-    version = "0.12.3"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-execute"
-    version = "0.9.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/procfile"
-    optional = true
-    version = "5.1.2"
-
-  [[order.group]]
-    id = "paketo-buildpacks/environment-variables"
-    optional = true
-    version = "4.1.2"
-
-  [[order.group]]
-    id = "paketo-buildpacks/image-labels"
-    optional = true
-    version = "4.1.2"
-
-[[order]]
-
-  [[order.group]]
-    id = "paketo-buildpacks/ca-certificates"
-    optional = true
-    version = "3.2.4"
-
-  [[order.group]]
-    id = "paketo-buildpacks/watchexec"
-    optional = true
-    version = "2.4.1"
-
-  [[order.group]]
-    id = "paketo-buildpacks/icu"
-    optional = true
-    version = "0.1.2"
 
   [[order.group]]
     id = "paketo-buildpacks/node-engine"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
An exploration in shaking up the buildpack order in the .NET buildpack.

- Use `runtimeconfig.json` to determine what runtimes (if any) are required at runtime.
- Make .NET publish buildpack responsible for requiring a specific .NET SDK version
- install ASP.NET as shipped by Microsoft (includes .NET runtime)
- install runtimes **after** `dotnet publish`, since they aren't needed in the build phase

To experiment with this spike:
- clone the ASP.NET, .NET SDK, .NET Publish, and .NET Execute buildpacks; for each, check out the `rearch-spike` branch
- build each of the component buildpacks
- replace their entries in this buildpack's `package.toml` with the paths to the local buildpackages
- build this composite buildpack locally
- use it to build apps!

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
