### PR TITLE
Test .NET 6 + Jammy Jellyfish

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -1,0 +1,3 @@
+{
+  "builders" : ["paketobuildpacks/builder:buildpackless-base", "paketobuildpacks/builder-jammy-buildpackless-base"]
+}

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"encoding/json"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -14,8 +16,18 @@ import (
 
 var dotnetCoreBuildpack string
 
+var config struct {
+	Builders []string `json:"builders"`
+}
+
 func TestIntegration(t *testing.T) {
 	Expect := NewWithT(t).Expect
+
+	file, err := os.Open("../integration.json")
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(json.NewDecoder(file).Decode(&config)).To(Succeed())
+	Expect(file.Close()).To(Succeed())
 
 	output, err := exec.Command("bash", "-c", "../scripts/package.sh --version 1.2.3").CombinedOutput()
 	Expect(err).NotTo(HaveOccurred(), string(output))


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The [Paketo Jammy Stacks RFC](https://github.com/paketo-buildpacks/rfcs/blob/ba9273ded6c65274276677b1ad5db5e61029060d/text/stacks/0004-jammy-jellyfish.md) has been accepted, and specifies that the Jammy Full and Base stacks will have the stack ID `io.buildpacks.stacks.jammy`. [.NET 3.1 does not work on Jammy Jellyfish](https://github.com/dotnet/core/issues/7038#issuecomment-1110377345) because it requires an outdated version of OpenSSL. So, this PR adds an integration test that ensure we can compile and run a .NET 6 source code app on Jammy Jellyfish.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This marks official Jammy support for the .NET Core buildpack.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
