### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.8"
   homepage = "https://github.com/paketo-buildpacks/dotnet-core"
   id = "paketo-buildpacks/dotnet-core"
   keywords = ["dotnet"]
-  name = "Paketo .NET Core Buildpack"
+  name = "Paketo Buildpack for .NET Core"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo .NET Core Buildpack' to 'Paketo Buildpack for .NET Core'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
