### PR TITLE
Rearchitect buildpack order groups (RFC 0006)

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -32,16 +32,8 @@ api = "0.8"
     version = "0.0.7"
 
   [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-runtime"
-    version = "0.10.9"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-aspnet"
-    optional = true
-    version = "0.9.10"
-
-  [[order.group]]
     id = "paketo-buildpacks/dotnet-core-sdk"
+    optional = true
     version = "0.10.1"
 
   [[order.group]]
@@ -56,67 +48,13 @@ api = "0.8"
 
   [[order.group]]
     id = "paketo-buildpacks/dotnet-publish"
+    optional = true
     version = "0.9.7"
 
   [[order.group]]
-    id = "paketo-buildpacks/dotnet-execute"
-    version = "0.12.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/procfile"
+    id = "paketo-buildpacks/dotnet-core-aspnet-runtime"
     optional = true
-    version = "5.4.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/environment-variables"
-    optional = true
-    version = "4.3.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/image-labels"
-    optional = true
-    version = "4.3.0"
-
-[[order]]
-
-  [[order.group]]
-    id = "paketo-buildpacks/ca-certificates"
-    optional = true
-    version = "3.4.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/watchexec"
-    optional = true
-    version = "2.7.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/vsdbg"
-    optional = true
-    version = "0.0.7"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-runtime"
-    version = "0.10.9"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-aspnet"
-    optional = true
-    version = "0.9.10"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-core-sdk"
-    optional = true
-    version = "0.10.1"
-
-  [[order.group]]
-    id = "paketo-buildpacks/icu"
-    optional = true
-    version = "0.5.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/node-engine"
-    optional = true
-    version = "0.18.0"
+    version = "0.0.3"
 
   [[order.group]]
     id = "paketo-buildpacks/dotnet-execute"
@@ -137,48 +75,3 @@ api = "0.8"
     optional = true
     version = "4.3.0"
 
-[[order]]
-
-  [[order.group]]
-    id = "paketo-buildpacks/ca-certificates"
-    optional = true
-    version = "3.4.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/watchexec"
-    optional = true
-    version = "2.7.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/vsdbg"
-    optional = true
-    version = "0.0.7"
-
-  [[order.group]]
-    id = "paketo-buildpacks/icu"
-    optional = true
-    version = "0.5.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/node-engine"
-    optional = true
-    version = "0.18.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/dotnet-execute"
-    version = "0.12.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/procfile"
-    optional = true
-    version = "5.4.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/environment-variables"
-    optional = true
-    version = "4.3.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/image-labels"
-    optional = true
-    version = "4.3.0"

--- a/integration/fdd_test.go
+++ b/integration/fdd_test.go
@@ -80,9 +80,7 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
-			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core SDK")))
+			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 
@@ -92,13 +90,9 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(Serve(ContainSubstring("<title>source_app</title>")).OnPort(8080))
 
 			// check that all required SBOM files are present
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-runtime", "dotnet-core-runtime", "sbom.cdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-runtime", "dotnet-core-runtime", "sbom.spdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-runtime", "dotnet-core-runtime", "sbom.syft.json")).To(BeARegularFile())
-
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet", "dotnet-core-aspnet", "sbom.cdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet", "dotnet-core-aspnet", "sbom.spdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet", "dotnet-core-aspnet", "sbom.syft.json")).To(BeARegularFile())
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet-runtime", "dotnet-core-aspnet-runtime", "sbom.cdx.json")).To(BeARegularFile())
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet-runtime", "dotnet-core-aspnet-runtime", "sbom.spdx.json")).To(BeARegularFile())
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet-runtime", "dotnet-core-aspnet-runtime", "sbom.syft.json")).To(BeARegularFile())
 
 			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_icu", "icu", "sbom.cdx.json")).To(BeARegularFile())
 			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_icu", "icu", "sbom.spdx.json")).To(BeARegularFile())
@@ -152,10 +146,8 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for CA Certificates")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core SDK")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 
 				container, err = docker.Container.Run.
@@ -218,18 +210,17 @@ func testFDD(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core SDK")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Watchexec")))
 
-				Expect(image.Buildpacks[8].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[8].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				envVar, err := image.BuildpackForKey("paketo-buildpacks/environment-variables")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(envVar.Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.

--- a/integration/fde_test.go
+++ b/integration/fde_test.go
@@ -81,8 +81,7 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
+			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 
@@ -92,13 +91,9 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(Serve(ContainSubstring("<title>source_app</title>")).OnPort(8080))
 
 			// check that all required SBOM files are present
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-runtime", "dotnet-core-runtime", "sbom.cdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-runtime", "dotnet-core-runtime", "sbom.spdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-runtime", "dotnet-core-runtime", "sbom.syft.json")).To(BeARegularFile())
-
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet", "dotnet-core-aspnet", "sbom.cdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet", "dotnet-core-aspnet", "sbom.spdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet", "dotnet-core-aspnet", "sbom.syft.json")).To(BeARegularFile())
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet-runtime", "dotnet-core-aspnet-runtime", "sbom.cdx.json")).To(BeARegularFile())
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet-runtime", "dotnet-core-aspnet-runtime", "sbom.spdx.json")).To(BeARegularFile())
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet-runtime", "dotnet-core-aspnet-runtime", "sbom.syft.json")).To(BeARegularFile())
 
 			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_icu", "icu", "sbom.cdx.json")).To(BeARegularFile())
 			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_icu", "icu", "sbom.spdx.json")).To(BeARegularFile())
@@ -152,9 +147,8 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for CA Certificates")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 
 				container, err = docker.Container.Run.
@@ -217,17 +211,17 @@ func testFDE(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Watchexec")))
 
-				Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				envVar, err := image.BuildpackForKey("paketo-buildpacks/environment-variables")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(envVar.Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.

--- a/integration/self_contained_test.go
+++ b/integration/self_contained_test.go
@@ -211,8 +211,9 @@ func testSelfContained(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Watchexec")))
 
-				Expect(image.Buildpacks[5].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[5].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				envVar, err := image.BuildpackForKey("paketo-buildpacks/environment-variables")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(envVar.Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.

--- a/integration/source_test.go
+++ b/integration/source_test.go
@@ -80,12 +80,11 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core SDK")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Engine")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Publish")))
+			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
@@ -94,13 +93,9 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(Serve(ContainSubstring("<title>source_app</title>")).OnPort(8080))
 
 			// check that all required SBOM files are present
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-runtime", "dotnet-core-runtime", "sbom.cdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-runtime", "dotnet-core-runtime", "sbom.spdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-runtime", "dotnet-core-runtime", "sbom.syft.json")).To(BeARegularFile())
-
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet", "dotnet-core-aspnet", "sbom.cdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet", "dotnet-core-aspnet", "sbom.spdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet", "dotnet-core-aspnet", "sbom.syft.json")).To(BeARegularFile())
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet-runtime", "dotnet-core-aspnet-runtime", "sbom.cdx.json")).To(BeARegularFile())
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet-runtime", "dotnet-core-aspnet-runtime", "sbom.spdx.json")).To(BeARegularFile())
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-core-aspnet-runtime", "dotnet-core-aspnet-runtime", "sbom.syft.json")).To(BeARegularFile())
 
 			Expect(filepath.Join(sbomDir, "sbom", "build", "paketo-buildpacks_dotnet-core-sdk", "dotnet-core-sdk", "sbom.cdx.json")).To(BeARegularFile())
 			Expect(filepath.Join(sbomDir, "sbom", "build", "paketo-buildpacks_dotnet-core-sdk", "dotnet-core-sdk", "sbom.spdx.json")).To(BeARegularFile())
@@ -162,11 +157,10 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for CA Certificates")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core SDK")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Publish")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 
 				container, err = docker.Container.Run.
@@ -229,19 +223,19 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core SDK")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Publish")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Watchexec")))
 
-				Expect(image.Buildpacks[10].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[10].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				envVar, err := image.BuildpackForKey("paketo-buildpacks/environment-variables")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(envVar.Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.
@@ -300,11 +294,10 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core SDK")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Publish")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
@@ -357,11 +350,10 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 					return cLogs.String()
 				}).Should(ContainSubstring(`Microsoft .NET Core Debugger (vsdbg)`))
 
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core Runtime")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Core SDK")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ICU")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Publish")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for ASP.NET Core Runtime")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for .NET Execute")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Visual Studio Debugger")))
 

--- a/package.toml
+++ b/package.toml
@@ -6,7 +6,7 @@
   uri = "urn:cnb:registry:paketo-buildpacks/dotnet-execute@0.12.0"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/dotnet-core-runtime@0.10.9"
+  uri = "urn:cnb:registry:paketo-buildpacks/dotnet-core-aspnet-runtime@0.0.3"
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/dotnet-core-sdk@0.10.1"
@@ -16,9 +16,6 @@
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/node-engine@0.18.0"
-
-[[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/dotnet-core-aspnet@0.9.10"
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/dotnet-publish@0.9.7"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
As part of #755, updates the order groups in the buildpack and updates integration tests accordingly. Notable changes in the integration tests:

- used the `BuildpackForKey` function from occam to make assertions about the environment-variables buildpack less brittle
- updated the filenames of the SBOMs that are expected outputs from builds; this represents a breaking change for users who may be looking specifically for hard-coded SBOM output paths for dotnet-core-runtime and dotnet-core-aspnet buildpacks.

Resolves #811

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
