### PR TITLE
Add UBI builders to integration tests

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -39,7 +39,7 @@ api = "0.8"
   [[order.group]]
     id = "paketo-buildpacks/icu"
     optional = true
-    version = "0.9.38"
+    version = "0.10.0"
 
   [[order.group]]
     id = "paketo-buildpacks/node-engine"

--- a/integration.json
+++ b/integration.json
@@ -6,5 +6,6 @@
     "index.docker.io/paketobuildpacks/builder-ubi8-buildpackless-base",
     "index.docker.io/paketobuildpacks/ubi-9-builder-buildpackless",
     "index.docker.io/paketobuildpacks/ubi-10-builder-buildpackless"
-  ]
+  ],
+  "ubi-nodejs-extension": "index.docker.io/paketobuildpacks/ubi-nodejs-extension"
 }

--- a/integration.json
+++ b/integration.json
@@ -2,6 +2,9 @@
   "builders": [
     "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base",
     "index.docker.io/paketobuildpacks/ubuntu-noble-builder-buildpackless",
-    "index.docker.io/paketobuildpacks/ubuntu-resolute-builder-buildpackless"
+    "index.docker.io/paketobuildpacks/ubuntu-resolute-builder-buildpackless",
+    "index.docker.io/paketobuildpacks/builder-ubi8-buildpackless-base",
+    "index.docker.io/paketobuildpacks/ubi-9-builder-buildpackless",
+    "index.docker.io/paketobuildpacks/ubi-10-builder-buildpackless"
   ]
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -1,18 +1,28 @@
 package integration_test
 
 import (
+	"encoding/json"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"testing"
 	"time"
 
+	"github.com/paketo-buildpacks/occam"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
 	. "github.com/onsi/gomega"
 )
 
-var dotnetCoreBuildpack string
+var (
+	dotnetCoreBuildpack string
+	ubiNodejsExtension  string
+	config              struct {
+		UbiNodejsExtension string `json:"ubi-nodejs-extension"`
+	}
+)
 
 func TestIntegration(t *testing.T) {
 	Expect := NewWithT(t).Expect
@@ -22,6 +32,24 @@ func TestIntegration(t *testing.T) {
 
 	dotnetCoreBuildpack, err = filepath.Abs("../build/buildpackage.cnb")
 	Expect(err).NotTo(HaveOccurred())
+
+	file, err := os.Open("../integration.json")
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(json.NewDecoder(file).Decode(&config)).To(Succeed())
+	Expect(file.Close()).To(Succeed())
+
+	pack := occam.NewPack()
+
+	builder, err := pack.Builder.Inspect.Execute()
+	Expect(err).NotTo(HaveOccurred())
+
+	isUbiBuilder := regexp.MustCompile(`ubi8`).MatchString(builder.BuilderName)
+
+	if isUbiBuilder {
+		Expect(occam.NewDocker().Pull.Execute(config.UbiNodejsExtension)).To(Succeed())
+		ubiNodejsExtension = config.UbiNodejsExtension
+	}
 
 	SetDefaultEventuallyTimeout(10 * time.Second)
 

--- a/integration/reproducible_builds_test.go
+++ b/integration/reproducible_builds_test.go
@@ -18,11 +18,17 @@ func testReproducibleBuilds(t *testing.T, context spec.G, it spec.S) {
 
 		pack   occam.Pack
 		docker occam.Docker
+
+		pullPolicy = "never"
 	)
 
 	it.Before(func() {
 		pack = occam.NewPack()
 		docker = occam.NewDocker()
+
+		if ubiNodejsExtension != "" {
+			pullPolicy = "always"
+		}
 	})
 
 	context("when building a .Net core app that is an FDD", func() {
@@ -199,8 +205,9 @@ func testReproducibleBuilds(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
+				WithExtensions(ubiNodejsExtension).
 				WithBuildpacks(dotnetCoreBuildpack).
-				WithPullPolicy("never").
+				WithPullPolicy(pullPolicy).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())
 
@@ -211,8 +218,9 @@ func testReproducibleBuilds(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
 
 			image, logs, err = pack.WithNoColor().Build.
+				WithExtensions(ubiNodejsExtension).
 				WithBuildpacks(dotnetCoreBuildpack).
-				WithPullPolicy("never").
+				WithPullPolicy(pullPolicy).
 				WithClearCache().
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())

--- a/integration/source_test.go
+++ b/integration/source_test.go
@@ -24,6 +24,8 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 
 		pack   occam.Pack
 		docker occam.Docker
+
+		pullPolicy = "never"
 	)
 
 	it.Before(func() {
@@ -49,6 +51,10 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 			sbomDir, err = os.MkdirTemp("", "sbom")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(os.Chmod(sbomDir, os.ModePerm)).To(Succeed())
+
+			if ubiNodejsExtension != "" {
+				pullPolicy = "always"
+			}
 		})
 
 		it.After(func() {
@@ -68,9 +74,10 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			image, logs, err = pack.WithNoColor().Build.
+				WithExtensions(ubiNodejsExtension).
 				WithBuildpacks(dotnetCoreBuildpack).
 				WithSBOMOutputDir(sbomDir).
-				WithPullPolicy("never").
+				WithPullPolicy(pullPolicy).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())
 
@@ -150,8 +157,9 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 				var logs fmt.Stringer
 
 				image, logs, err = pack.WithNoColor().Build.
+					WithExtensions(ubiNodejsExtension).
 					WithBuildpacks(dotnetCoreBuildpack).
-					WithPullPolicy("never").
+					WithPullPolicy(pullPolicy).
 					Execute(name, filepath.Join(source, "source-app"))
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 
@@ -219,8 +227,9 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 				var err error
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
+					WithExtensions(ubiNodejsExtension).
 					WithBuildpacks(dotnetCoreBuildpack).
-					WithPullPolicy("never").
+					WithPullPolicy(pullPolicy).
 					WithEnv(map[string]string{
 						"BPE_SOME_VARIABLE":      "some-value",
 						"BP_IMAGE_LABELS":        "some-label=some-value",
@@ -332,9 +341,10 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 					logs fmt.Stringer
 				)
 				image, logs, err = pack.WithNoColor().Build.
+					WithExtensions(ubiNodejsExtension).
 					WithBuildpacks(dotnetCoreBuildpack).
 					WithSBOMOutputDir(sbomDir).
-					WithPullPolicy("never").
+					WithPullPolicy(pullPolicy).
 					WithEnv(map[string]string{
 						"BP_DEBUG_ENABLED": "true",
 					}).

--- a/integration/source_test.go
+++ b/integration/source_test.go
@@ -113,9 +113,12 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_icu", "icu", "sbom.spdx.json")).To(BeARegularFile())
 			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_icu", "icu", "sbom.syft.json")).To(BeARegularFile())
 
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_node-engine", "node", "sbom.cdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_node-engine", "node", "sbom.spdx.json")).To(BeARegularFile())
-			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_node-engine", "node", "sbom.syft.json")).To(BeARegularFile())
+			// SBOM is not supported at the moment from UBI extension
+			if ubiNodejsExtension == "" {
+				Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_node-engine", "node", "sbom.cdx.json")).To(BeARegularFile())
+				Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_node-engine", "node", "sbom.spdx.json")).To(BeARegularFile())
+				Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_node-engine", "node", "sbom.syft.json")).To(BeARegularFile())
+			}
 
 			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-execute", "sbom.cdx.json")).To(BeARegularFile())
 			Expect(filepath.Join(sbomDir, "sbom", "launch", "paketo-buildpacks_dotnet-execute", "sbom.spdx.json")).To(BeARegularFile())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Add UBI builders to integration tests

This includes adding the UBI nodejs extension for UBI8 builder, otherwise this error occurs:
```
        [builder]         Determining projects to restore...
        [builder]         Restored /workspace/source-app.csproj (in 565 ms).
        [builder]         source-app -> /workspace/bin/Release/net8.0/linux-x64/source-app.dll
        [builder]         npm warn config dev Please use --include=dev instead.
        [builder]         npm error code UNABLE_TO_GET_ISSUER_CERT_LOCALLY
        [builder]         npm error errno UNABLE_TO_GET_ISSUER_CERT_LOCALLY
        [builder]         npm error request to https://registry.npmjs.org/zone.js/-/zone.js-0.11.5.tgz failed, reason: unable to get local issuer certificate
        [builder]         npm error A complete log of this run can be found in: /home/cnb/.npm/_logs/2026-08-15T04_35_36_411Z-debug-0.log
        [builder]       /workspace/source-app.csproj(44,5): error MSB3073: The command "npm --dev install" exited with code 1.
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
